### PR TITLE
🐞 Letter appears after hotkey on macbook

### DIFF
--- a/src/features/services-filter/hooks/hotkey-focus.ts
+++ b/src/features/services-filter/hooks/hotkey-focus.ts
@@ -7,6 +7,7 @@ export const useHotkeyFocus = () => {
 
   const keydownListener = (event: KeyboardEvent) => {
     if (event.altKey && event.code === 'KeyS') {
+      event.preventDefault()
       inputElement.value.focus()
     }
   }


### PR DESCRIPTION
The bug has been fixed. Now we call `event.preventDefault` when handling the hotkey.