### PR TITLE
✨ Deny WebSocket

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import { createApp } from 'vue'
 
 import { App } from './app'
 
+Object.defineProperty(window, 'WebSocket', { value: null })
+
 createApp(App).mount('#app')
 
 if (location.host && 'serviceWorker' in navigator) {


### PR DESCRIPTION
With this code, we sort of erase the WebSocket name. At a minimum, this will complicate the task for those who want to establish a connection from malicious code. I did not find another way to disable the WebSocket connection.