### PR TITLE
:bookmark: Implement Build and Hash GitHub Action for Main Branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - story-*
@@ -13,6 +16,7 @@ concurrency:
 
 jobs:
   lint:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎
@@ -28,6 +32,7 @@ jobs:
         run: npm run format
 
   type_check:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎
@@ -40,6 +45,7 @@ jobs:
         run: npm run type-check
 
   test:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -51,3 +57,27 @@ jobs:
 
       - name: Test 🧪
         run: npm run test
+
+  build-and-hash:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v3
+
+      - name: Install 👨🏻‍💻
+        run: npm i
+
+      - name: Build 🏗️
+        run: npm run build
+
+      - name: Calculate hash 🧮
+        run: sha256sum dist/index.html > sha256sum.txt
+
+      - name: Publish artifacts 📢
+        uses: actions/upload-artifact@v2
+        with:
+          name: Build artifacts
+          path: |
+            dist/index.html
+            sha256sum.txt

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v2.1.0'
+const CACHE_VERSION = 'v2.1.1'
 const ROOT_PATH = 'https://passcryptum.com/'
 const files = ['manifest.json', 'icon-192x192.png', 'icon-512x512.png']
 

--- a/src/widgets/app-header/components/AppHeader.vue
+++ b/src/widgets/app-header/components/AppHeader.vue
@@ -17,7 +17,7 @@ const { isEntered } = useAppHeader()
       <ServicesFilter v-if="isEntered" class="constant-services-filter" />
 
       <div class="header-content">
-        <NText class="app-version">2.1.0</NText>
+        <NText class="app-version">2.1.1</NText>
         <MenuButton :is-entered="isEntered" />
       </div>
     </div>


### PR DESCRIPTION
### Introduction
This Pull Request introduces the proposed `build-and-hash` job in our CI/CD pipeline. The new job is designed to enhance the integrity and transparency of our deployment process, particularly for the main branch.

### Changes Made
- Added a new job `build-and-hash` to the `.github/workflows/ci.yaml` file.
- Configured the job to trigger exclusively on push events to the `main` branch.
- The job includes steps for checking out the code, installing dependencies, building the project, calculating the SHA-256 hash of the resulting HTML file, and publishing both the HTML file and its hash as build artifacts.
- Modified the job execution flow to ensure that `build-and-hash` runs independently of other CI jobs, which are primarily focused on Pull Requests.

### Rationale
The primary motivation for these changes is to provide our users with verifiable proof that the HTML file on our domain is a direct build from the source code in the main branch. By automating the build and hash generation process, we are taking a significant step towards ensuring the integrity and authenticity of our deployments.
