### PR TITLE
:ambulance: Update NodeJS version in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,11 @@ jobs:
       - name: Checkout 🛎
         uses: actions/checkout@v3
 
+      - name: Set up NodeJS 🚉
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18
+
       - name: Install 👨🏻‍💻
         run: npm i
 
@@ -74,10 +79,13 @@ jobs:
       - name: Calculate hash 🧮
         run: sha256sum dist/index.html > sha256sum.txt
 
+      - name: Copy HTML file to root
+        run: cp dist/index.html passcryptum.html
+
       - name: Publish artifacts 📢
         uses: actions/upload-artifact@v2
         with:
           name: Build artifacts
           path: |
-            dist/index.html
+            passcryptum.html
             sha256sum.txt


### PR DESCRIPTION
This Pull Request introduces a hotfix to our CI workflow (`ci.yaml`) with two primary changes: updating the Node.js version to 18 and renaming the output HTML file to `passcryptum.html`. These changes are aimed at ensuring our CI process uses a current Node.js version and correctly reflects the branding of our product.
