### PR TITLE
🐞 Reset selection on new service addition

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v2.1.1'
+const CACHE_VERSION = 'v2.1.2'
 const ROOT_PATH = 'https://passcryptum.com/'
 const files = ['manifest.json', 'icon-192x192.png', 'icon-512x512.png']
 

--- a/src/entities/session/lib/services-options.ts
+++ b/src/entities/session/lib/services-options.ts
@@ -33,10 +33,10 @@ export const servicesOptions = computed(() =>
 watch(
   servicesCount,
   value => {
-    if (!value) {
-      selectedServiceName.value = null
-    } else if (value === 1) {
+    if (value === 1) {
       selectedServiceName.value = privateServices.value[0].name
+    } else {
+      selectedServiceName.value = null
     }
   },
   { immediate: true }

--- a/src/widgets/app-header/components/AppHeader.vue
+++ b/src/widgets/app-header/components/AppHeader.vue
@@ -17,7 +17,7 @@ const { isEntered } = useAppHeader()
       <ServicesFilter v-if="isEntered" class="constant-services-filter" />
 
       <div class="header-content">
-        <NText class="app-version">2.1.1</NText>
+        <NText class="app-version">2.1.2</NText>
         <MenuButton :is-entered="isEntered" />
       </div>
     </div>


### PR DESCRIPTION
The application actively tracks changes in the length of the service list. If, after a change, the number of services in the list is not exactly one, the current selection is reset, ensuring no service is selected by default. If, however, the service in the list turns out to be the only one, it will be selected as before.